### PR TITLE
FIX: Use matplotlib-supported interface

### DIFF
--- a/app/gui/frame/elastic_interval_frame.py
+++ b/app/gui/frame/elastic_interval_frame.py
@@ -102,9 +102,7 @@ class ElasticIntervalFrame(AbstractTabFrame):
         )
 
     def on_click(self, event):
-        if not event.inaxes:
-            return
-        if self.nav._active == "ZOOM":
+        if not event.inaxes or event.inaxes.get_navigate_mode() == "ZOOM":
             return
         interval = [None, None]
         interval[self.curr] = event.ydata


### PR DESCRIPTION
The newer version of matplotlib we're using for easier install on windows changed its internals in a way that broke the elastic-zone selection screen.

Turns out there is a method you can use to get the current "navigation mode" for an axes object: https://github.com/matplotlib/matplotlib/issues/18148

So I'm gonna use that.