### PR TITLE
Bugfix: Zero-line doesn't work in data trimming step

### DIFF
--- a/app/gui/frame/data_trim_frame.py
+++ b/app/gui/frame/data_trim_frame.py
@@ -111,9 +111,7 @@ class DataTrimFrame(AbstractTabFrame):
         self.canvas.draw()
 
     def on_click(self, event):
-        if not event.inaxes:
-            return
-        if self.nav._active == "ZOOM":
+        if not event.inaxes or event.inaxes.get_navigate_mode() == "ZOOM":
             return
         self._cs.set_zero(event.xdata)
         self.set_zeroline(event.xdata)


### PR DESCRIPTION
This change should have been part of the recent software upgrade work. The elastic-zone selectors had a similar issue when we upgraded matplotlib, but I failed to update this line like I updated the elastic zone code.