### PR TITLE
Fix "face color" on rendered PDF graphs

### DIFF
--- a/app/gui/frame/final_plot_frame.py
+++ b/app/gui/frame/final_plot_frame.py
@@ -50,7 +50,10 @@ class FinalPlotFrame(AbstractTabFrame):
         generate_sample_layer(s, info_file)
 
         pl_file = "{}temp/S{}_PL.pdf".format(pdf_dir, s.num)
-        self.peakloadframe.canvas.figure.savefig(pl_file)
+        self.peakloadframe.canvas.figure.savefig(
+            pl_file,
+            facecolor="white",
+        )
         create_pdf(
             info_file,
             project.template_file,
@@ -59,7 +62,10 @@ class FinalPlotFrame(AbstractTabFrame):
         )
 
         uts_file = "{}temp/S{}_UTS.pdf".format(pdf_dir, s.num)
-        self.utsframe.canvas.figure.savefig(uts_file)
+        self.utsframe.canvas.figure.savefig(
+            uts_file,
+            facecolor="white",
+        )
         create_pdf(
             info_file,
             project.template_file,
@@ -68,7 +74,10 @@ class FinalPlotFrame(AbstractTabFrame):
         )
 
         yl_file = "{}temp/S{}_YL.pdf".format(pdf_dir, s.num)
-        self.yieldloadframe.canvas.figure.savefig(yl_file)
+        self.yieldloadframe.canvas.figure.savefig(
+            yl_file,
+            facecolor="white",
+        )
         create_pdf(
             info_file,
             project.template_file,

--- a/app/gui/input_group/precision_input.py
+++ b/app/gui/input_group/precision_input.py
@@ -11,7 +11,7 @@ class PrecisionInputGroup(Frame):
         f = Frame(self)
         for i in range(3):
             r = Radiobutton(
-                f, variable=self._var, val=i, text="{}".format(10 ** i), font=font
+                f, variable=self._var, val=i, text="{}".format(10**i), font=font
             )
             self._buttons.append(r)
             r.pack(side=LEFT)

--- a/app/util/pdf.py
+++ b/app/util/pdf.py
@@ -14,6 +14,7 @@ LOGO_MARGIN = 0
 
 TEXT_MARGIN = 30
 
+
 def get_file_location(relative_path):
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         return str(Path(sys._MEIPASS) / relative_path)


### PR DESCRIPTION
Likely after updating dependencies, matplotlib now adds a gray "face color" to the rendered graphs when generating PDFs.

This PR explicitly sets the "facecolor" value to white when calling savefig.

PLUS running black on the codebase to fix some spacing.